### PR TITLE
reference user model using `get_user_model()` instead

### DIFF
--- a/webpush/models.py
+++ b/webpush/models.py
@@ -1,6 +1,6 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.core.exceptions import FieldError
+from django.conf import settings
 
 # Create your models here.
 
@@ -16,14 +16,14 @@ class SubscriptionInfo(models.Model):
 
 
 class PushInformation(models.Model):
-    user = models.ForeignKey(User, related_name='webpush_info', blank=True, null=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='webpush_info', blank=True, null=True)
     subscription = models.ForeignKey(SubscriptionInfo, related_name='webpush_info')
     group = models.ForeignKey(Group, related_name='webpush_info', blank=True, null=True)
 
     def save(self, force_insert=False, force_update=False, using=None):
         # Check whether user or the group field is present
         # At least one field should be present there
-        # Through from the functionality its not possible, just in case! ;) 
+        # Through from the functionality its not possible, just in case! ;)
         if self.user or self.group:
             super(PushInformation, self).save()
         else:


### PR DESCRIPTION
Referencing the User model using `django.contrib.auth.get_user_model()`

Signed-off-by: yxy <yxy.870@gmail.com>