### PR TITLE
Added details about subscription error in console log

### DIFF
--- a/webpush/static/webpush/webpush.js
+++ b/webpush/static/webpush/webpush.js
@@ -86,7 +86,7 @@ function subscribe(reg) {
     )
     .catch(
       function(error) {
-        console.log("error")
+        console.log('Subscription error.', error)
       }
     )
 }


### PR DESCRIPTION
For example, when I faced with #12, I just saw `error` in console, which is not helpful at all. After debugging I saw that real error was:

> DOMException: Registration failed - gcm_sender_id not found in manifest

We need to add such details to error so it will be more informative.