### PR TITLE
Move the json.dumps(payload) call to _send_notification.

### DIFF
--- a/webpush/__init__.py
+++ b/webpush/__init__.py
@@ -1,13 +1,10 @@
-import json
 
 from .utils import send_notification_to_group, send_notification_to_user
 
 
 def send_group_notification(group_name, payload, ttl=0):
-    payload = json.dumps(payload)
     send_notification_to_group(group_name, payload, ttl)
 
 
 def send_user_notification(user, payload, ttl=0):
-    payload = json.dumps(payload)
     send_notification_to_user(user, payload, ttl)

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.forms.models import model_to_dict
 
@@ -22,6 +24,7 @@ def send_notification_to_group(group_name, payload, ttl=0):
 def _send_notification(push_info, payload, ttl):
     subscription = push_info.subscription
     subscription_data = _process_subscription_info(subscription)
+    payload = json.dumps(payload)
     # Check if GCM info is provided in the settings
     if hasattr(settings,'WEBPUSH_SETTINGS'):
         gcm_key = settings.WEBPUSH_SETTINGS.get('GCM_KEY')


### PR DESCRIPTION
Because this method will fail if a dict is passed to it, this call
should be in _send_notification and not the methods in __init__.py
