### PR TITLE
[Issue #12] Adding configuration to exclude manifest in template

### DIFF
--- a/webpush/templates/manifest.html
+++ b/webpush/templates/manifest.html
@@ -1,0 +1,3 @@
+{% if request.user.is_authenticated or group %}
+  <link rel="manifest" href="{% url 'webpush_manifest_json' %}">
+{% endif %}

--- a/webpush/templates/webpush.html
+++ b/webpush/templates/webpush.html
@@ -3,5 +3,7 @@
 
   <script id="webpush-js" type="text/javascript" src="{% static 'webpush/webpush.js' %}"></script>
   <script id="service-worker-js" type="text/javascript" src="{% static 'webpush/webpush_serviceworker.js' %}"></script>
-  <link rel="manifest" href="{% url 'webpush_manifest_json' %}">
+  {% if include_manifest %}
+    <link rel="manifest" href="{% url 'webpush_manifest_json' %}">
+  {% endif %}
 {% endif %}

--- a/webpush/templates/webpush.html
+++ b/webpush/templates/webpush.html
@@ -3,7 +3,4 @@
 
   <script id="webpush-js" type="text/javascript" src="{% static 'webpush/webpush.js' %}"></script>
   <script id="service-worker-js" type="text/javascript" src="{% static 'webpush/webpush_serviceworker.js' %}"></script>
-  {% if include_manifest %}
-    <link rel="manifest" href="{% url 'webpush_manifest_json' %}">
-  {% endif %}
 {% endif %}

--- a/webpush/templatetags/webpush_notifications.py
+++ b/webpush/templatetags/webpush_notifications.py
@@ -1,4 +1,5 @@
 from django import template
+from django.conf import settings
 from django.core.urlresolvers import reverse
 
 register = template.Library()
@@ -9,7 +10,11 @@ register = template.Library()
 def webpush(context):
     group = context.get('webpush', {}).get('group')
     request = context['request']
-    return {'group': group, 'request': request}
+    # If the website already provide a manifest file, we should not include it
+    # into the template. If `MANIFEST` config is not provided,
+    # that means we should generate a manifest by default.
+    include_manifest = settings.WEBPUSH_SETTINGS.get("MANIFEST", True)
+    return {'group': group, 'include_manifest': include_manifest, 'request': request}
 
 
 @register.filter

--- a/webpush/templatetags/webpush_notifications.py
+++ b/webpush/templatetags/webpush_notifications.py
@@ -1,5 +1,4 @@
 from django import template
-from django.conf import settings
 from django.core.urlresolvers import reverse
 
 register = template.Library()
@@ -10,11 +9,15 @@ register = template.Library()
 def webpush(context):
     group = context.get('webpush', {}).get('group')
     request = context['request']
-    # If the website already provide a manifest file, we should not include it
-    # into the template. If `MANIFEST` config is not provided,
-    # that means we should generate a manifest by default.
-    include_manifest = settings.WEBPUSH_SETTINGS.get("MANIFEST", True)
-    return {'group': group, 'include_manifest': include_manifest, 'request': request}
+    return {'group': group, 'request': request}
+
+
+@register.filter
+@register.inclusion_tag('manifest.html', takes_context=True)
+def webpush_manifest(context):
+    group = context.get('webpush', {}).get('group')
+    request = context['request']
+    return {'group': group, 'request': request}
 
 
 @register.filter


### PR DESCRIPTION
It will add another configuration option from the settings. In the `WEBPUSH_SETTINGS` dictionary, just add `MANIFEST: False` and it will not include the manifest to the template. Need to add documentation for it.
@arogachev Can you please check if its working fine for you?
