### PR TITLE
send notification to a single subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,35 @@ So in order to send notification, see below.
     # Here in the user parameter, a user object should be passed
     # The user will get notification to all of his subscribed browser. A user can subscribe many browsers.
     ```
+ 
+- If you want fine grained control over sending a single push message, do like following
+
+
+    ```python
+    from webpush import WebPushException, send_single_notification
+
+    payload = {"head": "Welcome!", "body": "Hello World"}
+
+    user = request.user
+    push_infos = user.webpush_info.select_related("subscription")
+    for push_info in push_infos:
+        try:
+            send_single_notification(push_info.subscription, payload)
+
+        except WebPushException as ex:
+            extra = {"subscription": push_info.subscription, "exception": ex}
+            log.error("Sending Push notification failed.", extra=extra)
+            if "<Response [410]>" in str(ex):
+                # 410 = Endpoint Not Valid
+                # remove subscription
+                push_info.subscription.delete()
+
+    ```
+    
+
+
+ 
+ 
  **And the subscribers will get a notification like**
  ![Web Push Notification](http://i.imgur.com/VA6cxRc.png)
 

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -40,21 +40,8 @@ def send_notification_to_group(group_name, payload, ttl=0):
         raise WebPushException("Push failed.", extra=errors)
 
 
-def send_to_subscription(subscription, payload, ttl):
+def send_to_subscription(subscription, payload, ttl=0):
     _send_notification(subscription, payload, ttl)
-
-
-def send_to_subscriptions(queryset, payload, ttl):
-    errors = []
-    for subscription in queryset.all():
-        try:
-            _send_notification(subscription, payload, ttl)
-
-        except WebPushException as ex:
-            errors.append(dict(subscription=subscription, exception=ex))
-
-    if errors:
-        raise WebPushException("Push failed.", extra=errors)
 
 
 def _send_notification(subscription, payload, ttl):

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -1,4 +1,3 @@
-import warnings
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -8,12 +7,6 @@ from pywebpush import WebPushException, webpush
 
 def send_notification_to_user(user, payload, ttl=0):
     # Get all the push_info of the user
-
-    warnings.warn(
-        "send_notification_to_user is deprecated, "
-        "use send_to_subscriptions instead",
-        DeprecationWarning
-    )
 
     errors = []
     push_infos = user.webpush_info.select_related("subscription")
@@ -32,12 +25,6 @@ def send_notification_to_user(user, payload, ttl=0):
 def send_notification_to_group(group_name, payload, ttl=0):
     from .models import Group
     # Get all the subscription related to the group
-
-    warnings.warn(
-        "send_notification_to_group is deprecated, "
-        "use send_to_subscriptions instead",
-        DeprecationWarning
-    )
 
     errors = []
     push_infos = Group.objects.get(name=group_name).webpush_info.select_related("subscription")
@@ -59,7 +46,7 @@ def send_to_subscription(subscription, payload, ttl):
 
 def send_to_subscriptions(queryset, payload, ttl):
     errors = []
-    for subscription in queryset:
+    for subscription in queryset.all():
         try:
             _send_notification(subscription, payload, ttl)
 


### PR DESCRIPTION
added methods 
- send_to_subscription
- send_to_subscriptions  is replacement for user/group subscriptions
- handle exceptions in the loop