### PR TITLE
Serialize payload to JSON formatted string

### DIFF
--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -7,6 +9,7 @@ from pywebpush import webpush
 
 def send_notification_to_user(user, payload, ttl=0):
     # Get all the push_info of the user
+    payload = json.dumps(payload)
     push_infos = user.webpush_info.select_related("subscription")
     for push_info in push_infos:
         _send_notification(push_info, payload, ttl)


### PR DESCRIPTION
I realized that anytime my payload is in a dict format, I get this error while trying to send notifications. 

![Imgur](https://i.imgur.com/v0BRyJl.png)

To fix this issue, I had to use `json.dumps` on the payload. So I suggest either we fix the issue or advice the user to serialize the payload