### PR TITLE
Added ability to customize button class

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ Next, inside the `<body></body>` tag, insert `webush_button` where you would lik
 </body>
 ```
 
+Or if you want to add custom classes (e.g. bootstrap)
+
+```html
+<body>
+  <p> Hello World! </p>
+  # For django templating engine
+  {% webpush_button with_class="btn btn-outline-info" %}
+  # For jinja templating engine
+  {{ webpush_button(with_class="btn btn-outline-info") }}
+</body>
+```
+
  >**Note:** The Push Notification Button will show only if the user is logged in or any `group` named is passed through `webpush` context
 
  ***If you would like to mark the subscription as a group, like all person subscribe for push notification from the template should be marked as group and would get same notification, you should pass a `webpush` context to the template through views. The `webpush` context should have a dictionary like `{"group": group_name}`*** . Like following

--- a/webpush/jinja2.py
+++ b/webpush/jinja2.py
@@ -24,7 +24,9 @@ class WebPushExtension(Extension):
         return mark_safe(data)
 
     @contextfunction
-    def webpush_button(self, context):
+    def webpush_button(self, context, with_class=None):
         template_context = get_templatetag_context(context)
+        if with_class:
+            template_context['class'] = with_class
         data = render_to_string('webpush_button.html', template_context, using='django')
         return mark_safe(data)

--- a/webpush/templates/webpush_button.html
+++ b/webpush/templates/webpush_button.html
@@ -1,5 +1,5 @@
 {% if user.is_authenticated or group %}
-  <button id="webpush-subscribe-button" {% if group %}data-group="{{ group }}"{% endif %} data-url="{{ webpush_save_url }}">
+  <button id="webpush-subscribe-button" {% if class %}class="{{ class }}"{% endif %} {% if group %}data-group="{{ group }}"{% endif %} data-url="{{ webpush_save_url }}">
     Subscribe to Push Messaging
   </button>
   <div id="webpush-message" hidden></div>

--- a/webpush/templatetags/webpush_notifications.py
+++ b/webpush/templatetags/webpush_notifications.py
@@ -16,6 +16,7 @@ def webpush_header(context):
 
 @register.filter
 @register.inclusion_tag('webpush_button.html', takes_context=True)
-def webpush_button(context):
+def webpush_button(context, with_class):
     template_context = get_templatetag_context(context)
+    template_context['class'] = with_class
     return template_context

--- a/webpush/templatetags/webpush_notifications.py
+++ b/webpush/templatetags/webpush_notifications.py
@@ -16,7 +16,8 @@ def webpush_header(context):
 
 @register.filter
 @register.inclusion_tag('webpush_button.html', takes_context=True)
-def webpush_button(context, with_class):
+def webpush_button(context, with_class=None):
     template_context = get_templatetag_context(context)
-    template_context['class'] = with_class
+    if with_class:
+        template_context['class'] = with_class
     return template_context


### PR DESCRIPTION
For now, when I use the bootstrap CSS framework there is no ability to specify bootstrap classes for subscription button. In this patch I've added optional argument `with_class` for `webpush_button` snippet.