### PR TITLE
Replaced obsolete staticfiles tag

### DIFF
--- a/webpush/templates/webpush_header.html
+++ b/webpush/templates/webpush_header.html
@@ -1,5 +1,5 @@
 {% if user.is_authenticated or group %}
-  {% load staticfiles %}
+  {% load static %}
 
   <script id="webpush-js" type="text/javascript" src="{% static 'webpush/webpush.js' %}"></script>
   {# webpush_serviceworker.js render from template as it needs to be served from the same domain #}


### PR DESCRIPTION
In the patch I've replaces outdated `staticfiles` tag with it's new `static` version, available since Django 1.10 (see [details](https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#static))