### PR TITLE
feat: allow to send the headers parameters to pywebpush

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,7 @@ So in order to send notification, see below.
     ```python
     from webpush import send_user_notification
     
-    user = request.user
-    headers = { "topic" : "0", "urgency" = "normal" }
+    headers = { "topic" : "0", "urgency" : "normal" }
     payload = {"head": "Welcome!", "body": "Hello World"}
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ WEBPUSH_SETTINGS = {
 ```
 **Replace ``"Vapid Public Key"`` and ``"Vapid Private Key"`` with your Vapid Keys. Also replace ``admin@example.com`` with your email so that the push server of browser can reach to you if anything goes wrong.**
 
-    To send push notifications to the safari browser, write the email vapid as follows:
-    
-    ```python
-    VAPID_ADMIN_EMAIL='email@example.com'
-    ```
+To send push notifications to the safari browser, write the email vapid as follows:
+
+```python
+VAPID_ADMIN_EMAIL='email@example.com'
+```
     
 
 > **To know how to obtain Vapid Keys please see this [`py_vapid`](https://github.com/web-push-libs/vapid/tree/master/python) and [Google Developer Documentation](https://developers.google.com/web/fundamentals/push-notifications/subscribing-a-user#how_to_create_application_server_keys). You can obtain one easily from [web-push-codelab.glitch.me](https://web-push-codelab.glitch.me/). ``Application Server Keys`` and ``Vapid Keys`` both are same.**

--- a/README.md
+++ b/README.md
@@ -210,14 +210,21 @@ So in order to send notification, see below.
     ```python
     from webpush import send_user_notification
     
-    headers = { "topic" : "0", "urgency" : "normal" }
+    headers = {"topic": "0", "urgency": "normal"}
     payload = {"head": "Welcome!", "body": "Hello World"}
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
     
     ```
     
+    To send push notifications to the safari browser, write the email vapid as follows:
+    
+    ```python
+    VAPID_ADMIN_EMAIL='email@example.com'
+    ```
+    
     You can also send custom headers, for example, apple allows you to [send extra parameters](https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592), then you can use the headers argument to send them.
+    
     
     
 License

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ WEBPUSH_SETTINGS = {
 ```
 **Replace ``"Vapid Public Key"`` and ``"Vapid Private Key"`` with your Vapid Keys. Also replace ``admin@example.com`` with your email so that the push server of browser can reach to you if anything goes wrong.**
 
-To send push notifications to the safari browser, write the email vapid as follows:
-
-```python
-VAPID_ADMIN_EMAIL='email@example.com'
-```
+To send push notifications to the safari browser, be sure to write the vapid email as `'email@example.com'` instead of `'mailto:email@example.com'`
     
 
 > **To know how to obtain Vapid Keys please see this [`py_vapid`](https://github.com/web-push-libs/vapid/tree/master/python) and [Google Developer Documentation](https://developers.google.com/web/fundamentals/push-notifications/subscribing-a-user#how_to_create_application_server_keys). You can obtain one easily from [web-push-codelab.glitch.me](https://web-push-codelab.glitch.me/). ``Application Server Keys`` and ``Vapid Keys`` both are same.**

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ So in order to send notification, see below.
  ![Web Push Notification](http://i.imgur.com/VA6cxRc.png)
 
 
+- To send push notifications to the safari browser, apple allows you to pass custom headers, you can send them as follows:
+
+    headers = { "topic" : "0", "urgency" = "normal" }
+    send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
+
+    You can find more information at the following link:
+    https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592
+
 License
 =======
 ----

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ So in order to send notification, see below.
  ![Web Push Notification](http://i.imgur.com/VA6cxRc.png)
  
  
-    ```
 
 
 - To send push notifications to the safari browser, apple allows you to pass custom headers, you can send them as follows:

--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ So in order to send notification, see below.
     payload = {"head": "Welcome!", "body": "Hello World"}
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
-
+    
+    ```
     
     You can also send custom headers, for example, apple allows you to [send extra parameters](https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592), then you can use the headers argument to send them.
-    ```
+    
     
 License
 =======

--- a/README.md
+++ b/README.md
@@ -201,11 +201,15 @@ So in order to send notification, see below.
  
  **And the subscribers will get a notification like**
  ![Web Push Notification](http://i.imgur.com/VA6cxRc.png)
+ 
+ 
+    ```
 
 
 - To send push notifications to the safari browser, apple allows you to pass custom headers, you can send them as follows:
 
     headers = { "topic" : "0", "urgency" = "normal" }
+    
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
 
     You can find more information at the following link:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ WEBPUSH_SETTINGS = {
 ```
 **Replace ``"Vapid Public Key"`` and ``"Vapid Private Key"`` with your Vapid Keys. Also replace ``admin@example.com`` with your email so that the push server of browser can reach to you if anything goes wrong.**
 
+    To send push notifications to the safari browser, write the email vapid as follows:
+    
+    ```python
+    VAPID_ADMIN_EMAIL='email@example.com'
+    ```
+    
+
 > **To know how to obtain Vapid Keys please see this [`py_vapid`](https://github.com/web-push-libs/vapid/tree/master/python) and [Google Developer Documentation](https://developers.google.com/web/fundamentals/push-notifications/subscribing-a-user#how_to_create_application_server_keys). You can obtain one easily from [web-push-codelab.glitch.me](https://web-push-codelab.glitch.me/). ``Application Server Keys`` and ``Vapid Keys`` both are same.**
 
 Then include `webpush` in the `urls.py`
@@ -215,12 +222,6 @@ So in order to send notification, see below.
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
     
-    ```
-    
-    To send push notifications to the safari browser, write the email vapid as follows:
-    
-    ```python
-    VAPID_ADMIN_EMAIL='email@example.com'
     ```
     
     You can also send custom headers, for example, apple allows you to [send extra parameters](https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592), then you can use the headers argument to send them.

--- a/README.md
+++ b/README.md
@@ -208,12 +208,16 @@ So in order to send notification, see below.
 - To send push notifications to the safari browser, apple allows you to pass custom headers, you can send them as follows:
     
     ```python
+    from webpush import send_user_notification
+    
+    user = request.user
     headers = { "topic" : "0", "urgency" = "normal" }
+    payload = {"head": "Welcome!", "body": "Hello World"}
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
 
-    You can find more information at the following link:
-    https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592
+    
+    You can also send custom headers, for example, apple allows you to [send extra parameters](https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592), then you can use the headers argument to send them.
     ```
     
 License

--- a/README.md
+++ b/README.md
@@ -206,14 +206,16 @@ So in order to send notification, see below.
 
 
 - To send push notifications to the safari browser, apple allows you to pass custom headers, you can send them as follows:
-
+    
+    ```python
     headers = { "topic" : "0", "urgency" = "normal" }
     
     send_user_notification(user=user, payload=payload, ttl=1000, headers=headers)
 
     You can find more information at the following link:
     https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592
-
+    ```
+    
 License
 =======
 ----

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-webpush',
-    version='0.3.5',
+    version='0.3.6',
     packages=find_packages(),
     include_package_data=True,
     license='GNU Public License',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        'pywebpush==1.9.4'
+        'pywebpush>=1.9.4'
     ]
 )

--- a/webpush/__init__.py
+++ b/webpush/__init__.py
@@ -3,11 +3,11 @@ import json
 from .utils import send_notification_to_group, send_notification_to_user
 
 
-def send_group_notification(group_name, payload, ttl=0):
+def send_group_notification(group_name, payload, ttl=0, headers={}):
     payload = json.dumps(payload)
-    send_notification_to_group(group_name, payload, ttl)
+    send_notification_to_group(group_name, payload, ttl, headers=headers)
 
 
-def send_user_notification(user, payload, ttl=0):
+def send_user_notification(user, payload, ttl=0, headers={}):
     payload = json.dumps(payload)
-    send_notification_to_user(user, payload, ttl)
+    send_notification_to_user(user, payload, ttl, headers=headers)

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -5,28 +5,28 @@ from django.urls import reverse
 from pywebpush import WebPushException, webpush
 
 
-def send_notification_to_user(user, payload, ttl=0):
+def send_notification_to_user(user, payload, ttl=0, headers={}):
     # Get all the push_info of the user
 
     push_infos = user.webpush_info.select_related("subscription")
     for push_info in push_infos:
-        _send_notification(push_info.subscription, payload, ttl)
+        _send_notification(push_info.subscription, payload, ttl, headers=headers)
 
 
-def send_notification_to_group(group_name, payload, ttl=0):
+def send_notification_to_group(group_name, payload, ttl=0, headers={}):
     from .models import Group
     # Get all the subscription related to the group
 
     push_infos = Group.objects.get(name=group_name).webpush_info.select_related("subscription")
     for push_info in push_infos:
-        _send_notification(push_info.subscription, payload, ttl)
+        _send_notification(push_info.subscription, payload, ttl, headers=headers)
 
 
-def send_to_subscription(subscription, payload, ttl=0):
-    return _send_notification(subscription, payload, ttl)
+def send_to_subscription(subscription, payload, ttl=0, headers={}):
+    return _send_notification(subscription, payload, ttl, headers=headers)
 
 
-def _send_notification(subscription, payload, ttl):
+def _send_notification(subscription, payload, ttl, headers={}):
     subscription_data = _process_subscription_info(subscription)
     vapid_data = {}
 
@@ -43,7 +43,7 @@ def _send_notification(subscription, payload, ttl):
         }
 
     try:
-        req = webpush(subscription_info=subscription_data, data=payload, ttl=ttl, **vapid_data)
+        req = webpush(subscription_info=subscription_data, data=payload, ttl=ttl, headers=headers, **vapid_data)
         return req
     except WebPushException as e:
         # If the subscription is expired, delete it.

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -42,6 +42,19 @@ def _send_notification(subscription, payload, ttl, headers={}):
             'vapid_claims': {"sub": "mailto:{}".format(vapid_admin_email)}
         }
 
+    endpoint = subscription_data.get("endpoint")
+    if endpoint.startswith("https://web.push.apple.com"):
+        """
+        ttl, topic, urgency are required headers for web push notifications with Apple
+        Documentation:
+        https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592
+        """
+        
+        headers['ttl'] = str(headers.get("ttl", "0"))
+        headers['topic'] = str(headers.get("topic", "10"))
+        headers['urgency'] = headers.get("urgency", "normal")
+        
+
     try:
         req = webpush(subscription_info=subscription_data, data=payload, ttl=ttl, headers=headers, **vapid_data)
         return req

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -50,7 +50,7 @@ def _send_notification(subscription, payload, ttl, headers={}):
         https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_web_apps_safari_and_other_browsers#3994592
         """
         
-        headers['ttl'] = str(headers.get("ttl", "0"))
+        headers['ttl'] = str(headers.get("ttl", ttl))
         headers['topic'] = str(headers.get("topic", "10"))
         headers['urgency'] = headers.get("urgency", "normal")
         


### PR DESCRIPTION
* Version of `pywebpush` updated using `>=`  (Latest versions of pywebpush receive headers parameters).
* Added headers parameter to the `django-webpush` functions, empty dict by default.
* For apple web push notifications some headers are added by default.
* Documentation updated.