### PR TITLE
Fixed unwanted error 500 if form data is missing

### DIFF
--- a/webpush/views.py
+++ b/webpush/views.py
@@ -56,8 +56,8 @@ def process_subscription_data(post_data):
     keys = subscription_data.pop("keys", {})
     subscription_data.update(keys)
     # Insert the browser name and user agent
-    subscription_data["browser"] = post_data.pop("browser")
-    subscription_data["user_agent"] = post_data.pop("user_agent")
+    subscription_data["browser"] = post_data.pop("browser", None)
+    subscription_data["user_agent"] = post_data.pop("user_agent", None)
     return subscription_data
 
 


### PR DESCRIPTION
If the request to save webpush data has some fields missing, an error 500 is generated.

I think that this is unintended behaviour. With this default fields an error 400 is generated instead, given the validation performed after.