### PR TITLE
Add exclude_user_id Parameter to Prevent Self-Notifications in Group Messages

### DIFF
--- a/webpush/__init__.py
+++ b/webpush/__init__.py
@@ -2,11 +2,9 @@ import json
 
 from .utils import send_notification_to_group, send_notification_to_user
 
-
-def send_group_notification(group_name, payload, ttl=0):
+def send_group_notification(group_name, payload, ttl=0, exclude_user_id=None):
     payload = json.dumps(payload)
-    send_notification_to_group(group_name, payload, ttl)
-
+    send_notification_to_group(group_name, payload, ttl, exclude_user_id)
 
 def send_user_notification(user, payload, ttl=0):
     payload = json.dumps(payload)

--- a/webpush/utils.py
+++ b/webpush/utils.py
@@ -13,13 +13,19 @@ def send_notification_to_user(user, payload, ttl=0):
         _send_notification(push_info.subscription, payload, ttl)
 
 
-def send_notification_to_group(group_name, payload, ttl=0):
+def send_notification_to_group(group_name, payload, ttl=0, exclude_user_id=None):
     from .models import Group
-    # Get all the subscription related to the group
 
     push_infos = Group.objects.get(name=group_name).webpush_info.select_related("subscription")
+
+    # Exclude the current user from receiving notifications if they are part of the target group.
+    # This prevents users from receiving redundant notifications when they trigger an event themselves.
+    if exclude_user_id is not None:
+        push_infos = push_infos.exclude(user__id=exclude_user_id)
+
     for push_info in push_infos:
         _send_notification(push_info.subscription, payload, ttl)
+
 
 
 def send_to_subscription(subscription, payload, ttl=0):


### PR DESCRIPTION
## Summary
This pull request adds an optional `exclude_user_id` parameter to the `send_notification_to_group` and `send_group_notification` functions. The main objective is to allow the exclusion of a user from receiving notifications that they themselves have triggered within a group they are part of.

## Changes
- Add `exclude_user_id=None` parameter to `send_notification_to_group` in `utils.py`.
- Extend `send_group_notification` in `__init__.py` to support the new `exclude_user_id` parameter.
  
## Motivation
Before this change, if a user sent a notification to a group they belong to, they would receive the notification themselves. In scenarios where a user triggers an event that results in a group notification, this behavior leads to redundant and potentially confusing notifications for the user who initiated the action. This update provides a way to prevent such situations.

## Backward Compatibility
The changes introduced in this PR are backward-compatible. The new `exclude_user_id` parameter is optional, and omitting it will not affect the existing functionality.

