### PR TITLE
Fix to creating new subscription

### DIFF
--- a/webpush/models.py
+++ b/webpush/models.py
@@ -11,7 +11,7 @@ class Group(models.Model):
 
 class SubscriptionInfo(models.Model):
     browser = models.CharField(max_length=100)
-    user_agent = models.CharField(max_length=500)
+    user_agent = models.CharField(max_length=500, blank=True)
     endpoint = models.URLField(max_length=500)
     auth = models.CharField(max_length=100)
     p256dh = models.CharField(max_length=100)

--- a/webpush/views.py
+++ b/webpush/views.py
@@ -57,7 +57,7 @@ def process_subscription_data(post_data):
     subscription_data.update(keys)
     # Insert the browser name and user agent
     subscription_data["browser"] = post_data.pop("browser", None)
-    subscription_data["user_agent"] = post_data.pop("user_agent", None)
+    subscription_data["user_agent"] = post_data.pop("user_agent", '')
     return subscription_data
 
 


### PR DESCRIPTION
Currently, there is an issue creating new subscription if the user_agent is not specified in the post data. The issue is that the model does not state user_agent is nullable. 

To prevent creating another migration file, I've defaulted the user_agent value to blank and added in the model file to allow user_agent to be blank.