### PR TITLE
Fix management command wrong class name

### DIFF
--- a/webpush/management/commands/webpush_generate_vapid_keypair.py
+++ b/webpush/management/commands/webpush_generate_vapid_keypair.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from ...vapid import get_vapid_keypair
 
 
-class GenerateValidKeys(BaseCommand):
+class Command(BaseCommand):
     def handle(self, *args, **options):
         pubkey, privkey = get_vapid_keypair()
         self.stdout.write(f"Public key: {pubkey}")


### PR DESCRIPTION
Fixes #150 . @safwanrahman this needs to be merged before the next release because the management command introduced by #144 just doesn't work.